### PR TITLE
Checks on itlwm

### DIFF
--- a/HeliPort/AppDelegate.swift
+++ b/HeliPort/AppDelegate.swift
@@ -65,15 +65,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             "\n" +
             NSLocalizedString("itlwm API Version: ", comment: "") + String(drv_info.version)
         verAlert.addButton(withTitle: NSLocalizedString("Quit HeliPort", comment: "")).keyEquivalent = "\r"
-        verAlert.addButton(
-            withTitle: NSLocalizedString("Visit OpenIntelWireless on GitHub", comment: "")
-        )
+        #if DEBUG
+            verAlert.addButton(withTitle: NSLocalizedString("Dismiss", comment: ""))
+        #else
+            verAlert.addButton(withTitle: NSLocalizedString("Visit OpenIntelWireless on GitHub", comment: ""))
+        #endif
 
         NSApplication.shared.activate(ignoringOtherApps: true)
 
         if verAlert.runModal() == .alertSecondButtonReturn {
-            NSWorkspace.shared.open(URL(string: "https://github.com/OpenIntelWireless")!)
-            // Provide a chance to use this App in extreme conditions
+            #if !DEBUG
+                NSWorkspace.shared.open(URL(string: "https://github.com/OpenIntelWireless")!)
+            #endif
             return
         }
 

--- a/HeliPort/AppDelegate.swift
+++ b/HeliPort/AppDelegate.swift
@@ -38,6 +38,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let interface = String(cString: &drv_info.bsd_name.0)
         guard !version.isEmpty, !interface.isEmpty else {
             Log.error("itlwm kext not loaded!")
+            #if !DEBUG
+                alertDriverNotLoaded()
+            #endif
             return false
         }
 
@@ -75,5 +78,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
 
         NSApp.terminate(nil)
+    }
+
+    private func alertDriverNotLoaded() {
+        let verAlert = NSAlert()
+
+        verAlert.alertStyle = .critical
+        verAlert.messageText = NSLocalizedString("itlwm is not running", comment: "")
+        verAlert.informativeText = NSLocalizedString("Install and load itlwm", comment: "")
+        verAlert.addButton(withTitle: NSLocalizedString("Dismiss", comment: ""))
+
+        NSApplication.shared.activate(ignoringOtherApps: true)
+
+        verAlert.runModal()
     }
 }


### PR DESCRIPTION
Hi,
I modified the AppDelegate showing an alert when HeliPort is launched without itlwm installed. Pressing "Quit" nothing happens and the app closes, pressing "Continue" the app is launched and the app stores a bool named "itlwm". Now the app doesn't alert the user until the user launches HeliPort with itlwm running. In this case HeliPort change the value of "itlwm" and the next time HeliPort is launched without itlwm running the alert would be back.
I modified also the alert for the API mismatch. In this case the behaviour is similar to above but the button "Open OpenIntelWireless on GitHub" would be shown only the first time the mismatch is detected. If the user launches HeliPort with the correct version of itlwm, also this behaviour is resetted.
Worth noting that unfortunately this pull request includes also the changes of #86, I'm new at GitHub and I built the new branch "MIsmatch" after the commits of the precedent pull request.
If the request is granted it is needed to upgrade the translations.