### PR TITLE
Added reachability/error callback, improvements on StatusMenu layout

### DIFF
--- a/HeliPort/Appearance/StatusBarIconManager.swift
+++ b/HeliPort/Appearance/StatusBarIconManager.swift
@@ -66,6 +66,18 @@ class StatusBarIcon: NSObject {
         }
     }
 
+    class func warning() {
+        timer?.invalidate()
+        timer = nil
+        statusBar.button?.image = #imageLiteral(resourceName: "WiFiStateWarning")
+    }
+
+    class func error() {
+        timer?.invalidate()
+        timer = nil
+        statusBar.button?.image = #imageLiteral(resourceName: "WiFiStateError")
+    }
+
     class func signalStrength(RSSI: Int16) {
         timer?.invalidate()
         timer = nil

--- a/HeliPort/Appearance/StatusMenu.swift
+++ b/HeliPort/Appearance/StatusMenu.swift
@@ -45,9 +45,14 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
                 StatusBarIcon.connecting()
             case ITL80211_S_RUN:
                 DispatchQueue.global(qos: .background).async {
+                    let isReachable = NetworkManager.isReachable()
                     var staInfo = station_info_t()
                     get_station_info(&staInfo)
                     DispatchQueue.main.async {
+                        guard isReachable else {
+                            StatusBarIcon.warning()
+                            return
+                        }
                         StatusBarIcon.signalStrength(RSSI: staInfo.rssi)
                     }
                 }
@@ -451,7 +456,7 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
                                           range: nil)
                 let ipAddress = NetworkManager.getLocalAddress(bsd: bsd)
                 let routerAddress = NetworkManager.getRouterAddress(bsd: bsd)
-                let isReachable = NetworkManager.checkConnectionReachability(station: staInfo)
+                let isReachable = NetworkManager.isReachable()
                 disconnectName = String(cString: &staInfo.ssid.0)
                 ipAddr = ipAddress ?? NSLocalizedString("Unknown", comment: "")
                 routerAddr = routerAddress ?? NSLocalizedString("Unknown", comment: "")

--- a/HeliPort/Appearance/StatusMenu.swift
+++ b/HeliPort/Appearance/StatusMenu.swift
@@ -109,7 +109,7 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
             }
 
             // Create Network... has not been implemented in itlwm
-            items[items.count - 7].isHidden = true
+            items[items.count - 8].isHidden = true
 
             for idx in 1...4 {
                 items[items.count - idx].isHidden = !visible
@@ -140,7 +140,7 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
 
             for inx in 6...9 {
                 // TODO: Create Network... has not been implemented in itlwm
-                if inx == 7 {
+                if inx == 8 {
                     continue
                 }
                 // Hide items that cannot be used while card is not working

--- a/HeliPort/Appearance/StatusMenu.swift
+++ b/HeliPort/Appearance/StatusMenu.swift
@@ -107,7 +107,7 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
             // Create Network... has not been implemented in itlwm
             items[items.count - 7].isHidden = true
 
-            for idx in 1...2 {
+            for idx in 1...4 {
                 items[items.count - idx].isHidden = !visible
             }
         }
@@ -266,10 +266,13 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
 
         addItem(NSMenuItem.separator())
 
+        addClickItem(title: NSLocalizedString("About HeliPort", comment: ""))
         addItem(toggleLaunchItem)
         toggleLaunchItem.target = self
-        addClickItem(title: NSLocalizedString("About HeliPort", comment: ""))
         addClickItem(title: NSLocalizedString("Check for Updates...", comment: ""))
+
+        addItem(NSMenuItem.separator())
+
         addClickItem(title: NSLocalizedString("Quit HeliPort", comment: ""), keyEquivalent: "q")
     }
 

--- a/HeliPort/Appearance/StatusMenu.swift
+++ b/HeliPort/Appearance/StatusMenu.swift
@@ -82,6 +82,7 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
         willSet(visible) {
             for idx in 0...6 {
                 /*
+                 * Hide top items if the Options button is not pressed.
                  * TODO: idx 3, 4, 5 have not been implemented
                  * 3: Enable Wi-Fi Logging
                  * 4: Create Diagnostics Report...
@@ -96,6 +97,8 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
 
             for idx in 11...24 {
                 /*
+                 * Hide items for which when there is no Wi-Fi connection and
+                 * Options button is not pressed.
                  * idx 15, 18, 24 have not been implemented in io_station_info
                  * 15: security
                  * 18: country code
@@ -111,6 +114,13 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
             // Create Network... has not been implemented in itlwm
             items[items.count - 8].isHidden = true
 
+            /*
+             * Hide bottom items if the Options button is not pressed:
+             * item.count - 1: Quit HeliPort
+             * item.count - 2: NSMenuItem.separator()
+             * item.count - 3: Check for Updates
+             * item.count - 4: Launch at Login
+             */
             for idx in 1...4 {
                 items[items.count - idx].isHidden = !visible
             }
@@ -143,7 +153,14 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
                 if inx == 8 {
                     continue
                 }
-                // Hide items that cannot be used while card is not working
+
+                /*
+                 * Hide items that cannot be used while card is not working
+                 * items.count - 6: Open Network Preferences...
+                 * items.count - 7: Create Network...
+                 * items.count - 8: Join Other Network...
+                 * items.count - 9: networkItemListSeparator
+                 */
                 items[items.count - inx].isHidden = !newState
             }
         }

--- a/HeliPort/NetworkManager.swift
+++ b/HeliPort/NetworkManager.swift
@@ -190,7 +190,7 @@ final class NetworkManager {
         return addressBytes.joined(separator: separator)
     }
 
-    class func checkConnectionReachability(station: station_info_t) -> Bool {
+    class func isReachable() -> Bool {
         guard let reachability = SCNetworkReachabilityCreateWithName(nil, "www.apple.com") else {
             return false
         }

--- a/HeliPort/Supporting files/itl_80211_state+Description.swift
+++ b/HeliPort/Supporting files/itl_80211_state+Description.swift
@@ -27,7 +27,7 @@ extension itl_80211_state: CustomStringConvertible {
         case ITL80211_S_RUN:
             return "Wi-Fi: Connected"
         default:
-            return "Wi-Fi: Off"
+            return "Wi-Fi: Kext not loaded"
         }
     }
 }

--- a/HeliPort/Supporting files/itl_80211_state+Description.swift
+++ b/HeliPort/Supporting files/itl_80211_state+Description.swift
@@ -27,7 +27,7 @@ extension itl_80211_state: CustomStringConvertible {
         case ITL80211_S_RUN:
             return "Wi-Fi: Connected"
         default:
-            return "Wi-Fi: Kext not loaded"
+            return "Wi-Fi: Status unavailable"
         }
     }
 }


### PR DESCRIPTION
Hey everyone!

This pull request includes a few cleanups on the reachability api and now the StatusBarMenuIcon shows the warning icon if there is an issue with reachability.

Another thing I added is to detect if there is an error getting a value from itlwm, i.e. unloading kext or other future implementations on wifi card errors, it now shows the error symbol.
- In order to achieve this, I added a `isNetworkCardAvailable` variable that sets if the network card is available. If it is not, it hides "Join other network", "Create Network" (it's already hidden), and "Open Network Preferenes".

Lastly, I hid the "Launch on startup" to only show when pressing Options + WiFi symbol. Also cleaned a bit of the UI for where it shows the "Quit" button.

Ready for review!