### PR TITLE
Autojoin enabled/disabled on disconnect/connect, no frozen Keychain auth

### DIFF
--- a/HeliPort/Appearance/StatusMenu.swift
+++ b/HeliPort/Appearance/StatusMenu.swift
@@ -523,7 +523,11 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
                                   options: .regularExpression,
                                   range: nil
         )
-        dis_associate_ssid(ssid)
-        print("disconnected from \(ssid)")
+        
+        DispatchQueue.global().async {
+            CredentialsManager.instance.setAutoJoin(ssid, false)
+            dis_associate_ssid(ssid)
+            print("disconnected from \(ssid)")
+        }
     }
 }

--- a/HeliPort/CredentialsManager.swift
+++ b/HeliPort/CredentialsManager.swift
@@ -71,9 +71,12 @@ final class CredentialsManager {
     }
     
     func setAutoJoin(_ ssid: String,_ autoJoin: Bool) {
-        let entity = getStorageFromSsid(ssid)
-        let auth = getAuthFromSsid(ssid)
-        entity?.autoJoin = autoJoin
+        guard let entity = getStorageFromSsid(ssid),
+            let auth = getAuthFromSsid(ssid) else {
+                return
+        }
+        
+        entity.autoJoin = autoJoin
         
         guard let entityJson = try? String(data: JSONEncoder().encode(entity), encoding: .utf8),
             let authJson = try? String(data: JSONEncoder().encode(auth), encoding: .utf8) else {

--- a/HeliPort/CredentialsManager.swift
+++ b/HeliPort/CredentialsManager.swift
@@ -49,15 +49,43 @@ final class CredentialsManager {
         Log.debug("Loading password for network \(network.ssid)")
         return try? JSONDecoder().decode(NetworkAuth.self, from: jsonData)
     }
+    
+    func getStorageFromSsid(_ ssid: String) -> NetworkInfoStorageEntity? {
+        guard let attributes = try? keychain.get(ssid, handler: {$0}),
+            let json = attributes.comment,
+            let jsonData = json.data(using: .utf8) else {
+                return nil
+        }
+
+        return try? JSONDecoder().decode(NetworkInfoStorageEntity.self, from: jsonData)
+    }
+    
+    func getAuthFromSsid(_ ssid: String) -> NetworkAuth? {
+        guard let attributes = try? keychain.get(ssid, handler: {$0}),
+            let jsonData = attributes.data
+            else {
+                return nil
+        }
+        
+        return try? JSONDecoder().decode(NetworkAuth.self, from: jsonData)
+    }
+    
+    func setAutoJoin(_ ssid: String,_ autoJoin: Bool) {
+        let entity = getStorageFromSsid(ssid)
+        let auth = getAuthFromSsid(ssid)
+        entity?.autoJoin = autoJoin
+        
+        guard let entityJson = try? String(data: JSONEncoder().encode(entity), encoding: .utf8),
+            let authJson = try? String(data: JSONEncoder().encode(auth), encoding: .utf8) else {
+            return
+        }
+        
+        try? keychain.comment(entityJson).set(authJson, key: ssid)
+    }
 
     func getSavedNetworks() -> [NetworkInfo] {
         return (keychain.allKeys().compactMap { ssid in
-            guard let attributes = try? keychain.get(ssid, handler: {$0}),
-                let json = attributes.comment,
-                let jsonData = json.data(using: .utf8) else {
-                return nil
-            }
-            return try? JSONDecoder().decode(NetworkInfoStorageEntity.self, from: jsonData)
+            return getStorageFromSsid(ssid)
         } as [NetworkInfoStorageEntity]).filter { entity in
             entity.autoJoin && entity.version == NetworkInfoStorageEntity.CURRENT_VERSION
         }.sorted {


### PR DESCRIPTION
The keychain auth popups will freeze HeliPort if they are on the main thread ([source](https://github.com/kishikawakatsumi/KeychainAccess#-cyclone-touch-id-face-id-integration)). I moved these off of the main thread, though I'm not sure if there is a better way to do it? This is my first time looking at swift, so I'm not familiar with async tasks and best practices.

Additionally, I put in code to set autojoin to be enabled or disabled, so that if a user clicks disconnect, HeliPort won't connect right back to it unless the user clicks the network again. This would be for whenever `connectSavedNetworks` actually gets called, as right now it seems to only be called on init, and even then it doesn't appear to actually run.