### PR TITLE
Refactor Connected Network Item

### DIFF
--- a/ClientKit/Api.c
+++ b/ClientKit/Api.c
@@ -127,7 +127,6 @@ bool get_network_list(network_info_list_t *list) {
         strncpy(info->SSID, (char*) network_info_ret.ssid, 32);
         info->RSSI = network_info_ret.rssi;
         info->auth.security = analyse_security(&network_info_ret);
-        info->is_connected = false;
     }
     close_adapter(con);
 

--- a/ClientKit/Api.c
+++ b/ClientKit/Api.c
@@ -108,18 +108,10 @@ bool get_network_list(network_info_list_t *list) {
     struct ioctl_network_info network_info_ret;
     io_connect_t con;
     struct ioctl_sta_info sta_info;
-    uint32_t state;
     scan.version = IOCTL_VERSION;
 
-    if (get_80211_state(&state) && state == ITL80211_S_RUN) {
-        if (get_station_info(&sta_info) == KERN_SUCCESS) {
-            list->count = 1;
-            strncpy(list->networks[0].SSID, (char*) sta_info.ssid, 32);
-            list->networks[0].RSSI = sta_info.rssi;
-            list->networks[0].auth.security = ITL80211_CIPHER_NONE;//will update below
-            list->networks[0].is_connected = true;
-        }
-    }
+    get_station_info(&sta_info);
+
     if (!open_adapter(&con)) {
         goto error;
     }
@@ -128,16 +120,14 @@ bool get_network_list(network_info_list_t *list) {
         if (list->count >= MAX_NETWORK_LIST_LENGTH) {
             break;
         }
+        if (memcmp(sta_info.bssid, network_info_ret.bssid, ETHER_ADDR_LEN) == 0) {
+            continue;
+        }
         network_info_t *info = &list->networks[list->count++];
         strncpy(info->SSID, (char*) network_info_ret.ssid, 32);
         info->RSSI = network_info_ret.rssi;
-        // info->auth.security = network_info_ret.ni_rsncipher;
         info->auth.security = analyse_security(&network_info_ret);
         info->is_connected = false;
-        if (memcmp(sta_info.bssid, network_info_ret.bssid, ETHER_ADDR_LEN) == 0) {
-            info->is_connected = true;
-            list->networks[0].auth.security = info->auth.security;
-        }
     }
     close_adapter(con);
 

--- a/ClientKit/Api.h
+++ b/ClientKit/Api.h
@@ -42,7 +42,6 @@ typedef struct {
 
 typedef struct {
     char SSID[MAX_SSID_LENGTH + 1];
-    bool is_connected;
     int RSSI;
     network_auth_t auth;
 } network_info_t;

--- a/HeliPort/Appearance/StatusMenu.swift
+++ b/HeliPort/Appearance/StatusMenu.swift
@@ -351,11 +351,7 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
             keyEquivalent: ""
         )
         item.view = WifiMenuItemView(
-            networkInfo: NetworkInfo(
-                ssid: "placeholder",
-                connected: false,
-                rssi: 0
-            )
+            networkInfo: NetworkInfo(ssid: "placeholder")
         )
         guard let view = item.view as? WifiMenuItemView else {
             return item
@@ -497,10 +493,10 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
                 self.nssItem.title = NSLocalizedString("    NSS: ", comment: "") + nss
                 if let wifiItemView = self.networkItemList[0].view as? WifiMenuItemView {
                     wifiItemView.visible = connected
+                    wifiItemView.connected = connected
                     if connected {
                         wifiItemView.networkInfo = NetworkInfo(
                             ssid: String(cString: &staInfo.ssid.0),
-                            connected: true,
                             rssi: Int(staInfo.rssi)
                         )
                     }

--- a/HeliPort/Appearance/StatusMenu.swift
+++ b/HeliPort/Appearance/StatusMenu.swift
@@ -491,7 +491,9 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
                 self.phyModeItem.title = NSLocalizedString("    PHY Mode: ", comment: "") + phyMode
                 self.mcsIndexItem.title = NSLocalizedString("    MCS Index: ", comment: "") + mcsIndex
                 self.nssItem.title = NSLocalizedString("    NSS: ", comment: "") + nss
-                if let wifiItemView = self.networkItemList[0].view as? WifiMenuItemView {
+                 guard self.isNetworkCardEnabled, let wifiItemView = self.networkItemList[0].view as? WifiMenuItemView else {
+                    return
+                }
                     wifiItemView.visible = connected
                     wifiItemView.connected = connected
                     if connected {

--- a/HeliPort/Appearance/StatusMenu.swift
+++ b/HeliPort/Appearance/StatusMenu.swift
@@ -497,6 +497,7 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
                     wifiItemView.visible = connected
                     wifiItemView.connected = connected
                     if connected {
+                        self.isNetworkListEmpty = false
                         wifiItemView.networkInfo = NetworkInfo(
                             ssid: String(cString: &staInfo.ssid.0),
                             rssi: Int(staInfo.rssi)

--- a/HeliPort/Appearance/WiFiMenuItemView.swift
+++ b/HeliPort/Appearance/WiFiMenuItemView.swift
@@ -24,6 +24,7 @@ class WifiMenuItemView: NSView {
         statusImage.image?.isTemplate = true
         statusImage.translatesAutoresizingMaskIntoConstraints = false
         statusImage.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        statusImage.isHidden = true
         return statusImage
     }()
 
@@ -77,11 +78,16 @@ class WifiMenuItemView: NSView {
         }
     }
 
+    var connected: Bool = false {
+        willSet(connected) {
+            statusImage.isHidden = !connected
+        }
+    }
+
     var currentWindow: NSWindow?
 
     var networkInfo: NetworkInfo {
         willSet(networkInfo) {
-            statusImage.isHidden = !networkInfo.isConnected
             ssidLabel.stringValue = networkInfo.ssid
             lockImage.isHidden = networkInfo.auth.security == ITL80211_SECURITY_NONE
             signalImage.image = WifiMenuItemView.getRssiImage(networkInfo.rssi)
@@ -136,7 +142,9 @@ class WifiMenuItemView: NSView {
     override func mouseUp(with event: NSEvent) {
         isMouseOver = false // NSWindow pop up could escape mouseExit
         enclosingMenuItem?.menu?.cancelTracking()
-        NetworkManager.connect(networkInfo: networkInfo)
+        if !connected {
+            NetworkManager.connect(networkInfo: networkInfo)
+        }
     }
 
     override func viewWillMove(toWindow newWindow: NSWindow?) {

--- a/HeliPort/NetworkManager.swift
+++ b/HeliPort/NetworkManager.swift
@@ -29,9 +29,6 @@ final class NetworkManager {
 
     class func connect(networkInfo: NetworkInfo, saveNetwork: Bool = false,
                        _ callback: ((_ result: Bool) -> Void)? = nil) {
-        guard !networkInfo.isConnected else {
-            return
-        }
 
         guard supportedSecurityMode.contains(networkInfo.auth.security) else {
             let alert = NSAlert()
@@ -51,7 +48,6 @@ final class NetworkManager {
                 networkInfo.ssid,
                 Int(MAX_SSID_LENGTH)
             )
-            networkInfoStruct.is_connected = false
             networkInfoStruct.RSSI = Int32(networkInfo.rssi)
 
             networkInfoStruct.auth.security = auth.security.rawValue
@@ -120,7 +116,6 @@ final class NetworkManager {
 
                 let networkInfo = NetworkInfo(
                     ssid: ssid,
-                    connected: network!.is_connected,
                     rssi: Int(network!.RSSI)
                 )
                 networkInfo.auth.security = itl80211_security(rawValue: network?.auth.security ?? 0)
@@ -129,7 +124,7 @@ final class NetworkManager {
             }
 
             DispatchQueue.main.async {
-                callback(Array(result).sorted { $0.ssid < $1.ssid }.sorted { $0.isConnected && !$1.isConnected })
+                callback(Array(result).sorted { $0.ssid < $1.ssid })
             }
         }
     }

--- a/HeliPort/Supporting files/NetworkManager+Data.swift
+++ b/HeliPort/Supporting files/NetworkManager+Data.swift
@@ -17,14 +17,12 @@ import Foundation
 
 final class NetworkInfo: Codable {
     let ssid: String
-    let isConnected: Bool
     var rssi: Int
 
     var auth = NetworkAuth()
 
-    init (ssid: String, connected: Bool = false, rssi: Int = 0) {
+    init (ssid: String, rssi: Int = 0) {
         self.ssid = ssid
-        self.isConnected = connected
         self.rssi = rssi
     }
 }
@@ -48,7 +46,7 @@ final class NetworkAuth: Codable {
 }
 
 final class NetworkInfoStorageEntity: Codable {
-    static let CURRENT_VERSION: UInt = 1
+    static let CURRENT_VERSION: UInt = 2
 
     var version: UInt = CURRENT_VERSION
     var autoJoin: Bool = true


### PR DESCRIPTION
- Remove `isConnected` field in `NetworkInfo`.
- Update connected network item in `updateNetworkInfo()`. Fix #92.