### PR TITLE
Fixed getting router IP from itlwm interface

### DIFF
--- a/HeliPort/NetworkManager.swift
+++ b/HeliPort/NetworkManager.swift
@@ -186,6 +186,9 @@ final class NetworkManager {
     }
 
     class func getRouterAddress(bsd: String) -> String? {
+        // from Goshin
+        let ipAddressRegex = #"\s([a-fA-F0-9\.:]+)(\s|%)"# // for ipv4 and ipv6
+
         let routerCommand = ["netstat -rn | egrep -o default.*\(bsd)"]
         guard let routerOutput = commandLine(args: routerCommand) else {
             return nil
@@ -291,8 +294,6 @@ final class NetworkManager {
 }
 
 extension NetworkManager {
-    // from Goshin
-    private static let ipAddressRegex = #"\s([a-fA-F0-9\.:]+)(\s|%)"# // for ipv4 and ipv6
 
     // Util for running commands
     static func commandLine(args: [String]) -> String? {


### PR DESCRIPTION
Hey!

This pull request fixes an issue with getting router IP address from itlwm interface, rather than getting it from the primary interface, which could've been on a different network or with a different router.

Should fix #104 

Thanks to @Goshin  for the workaround!

Ready for review!