### PR TITLE
Auto join to networks whenever not connected

### DIFF
--- a/HeliPort/NetworkManager.swift
+++ b/HeliPort/NetworkManager.swift
@@ -27,6 +27,8 @@ final class NetworkManager {
         ITL80211_SECURITY_PERSONAL
     ]
 
+    static var credentialLock = false
+
     class func connect(networkInfo: NetworkInfo, saveNetwork: Bool = false,
                        _ callback: ((_ result: Bool) -> Void)? = nil) {
 
@@ -107,17 +109,36 @@ final class NetworkManager {
         }
     }
 
-    class func connectSavedNetworks() {
+    class func connectSavedNetworks(_ scannedNetworks: [NetworkInfo]) {
         DispatchQueue.global(qos: .background).async {
             let dispatchSemaphore = DispatchSemaphore(value: 0)
             var connected = false
-            for network in CredentialsManager.instance.getSavedNetworks() where !connected {
+
+            // We can get here stuck below for a bit waiting for credential passwords.
+            // Only allow one autoconnect request at a time and drop the rest
+            if self.credentialLock {
+                return
+            }
+
+            self.credentialLock = true
+
+            // Filter for only scanned networks
+            let savedNetworks = CredentialsManager.instance.getSavedNetworks()
+                .filter { entity in
+                    scannedNetworks.contains { element in
+                        element.ssid == entity.ssid }
+            }
+
+            for network in savedNetworks where !connected {
+                Log.debug("Auto-joining \(network.ssid)")
                 connect(networkInfo: network) { (result: Bool) -> Void in
                     connected = result
                     dispatchSemaphore.signal()
                 }
                 dispatchSemaphore.wait()
             }
+
+            self.credentialLock = false
         }
     }
 


### PR DESCRIPTION
Whenever HeliPort gets scanned networks, it'll compare them with stored networks and autoconnect if it matches a stored network. It will only do this when not connected.

I did move the network updates over to the same timer that updates the status, as it made it a little easier to get the scanned networks without calling `scanNetwork` again. Though, this can be changed