### PR TITLE
Fixed issue where long ssid's were not being saved in keychain

### DIFF
--- a/ClientKit/Api.c
+++ b/ClientKit/Api.c
@@ -112,7 +112,7 @@ bool connect_network(const char *ssid, const char *pwd) {
         if (get_80211_state(&state) && state == ITL80211_S_RUN) {
             station_info_t sta_info;
             if (get_station_info(&sta_info) == KERN_SUCCESS) {
-                return strcmp(ssid, (char*)sta_info.ssid) == 0;
+                return strncmp(ssid, (char*)sta_info.ssid, NWID_LEN) == 0;
             }
         }
         sleep(1);

--- a/HeliPort.xcodeproj/project.pbxproj
+++ b/HeliPort.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1317990B256986E5006957D8 /* String+NonNullTerminated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1317990A256986E5006957D8 /* String+NonNullTerminated.swift */; };
 		1380C36124D54BFD00A448CF /* PrefsSavedNetworksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1380C36024D54BFD00A448CF /* PrefsSavedNetworksView.swift */; };
 		1380C36524D5580200A448CF /* PrefsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1380C36424D5580200A448CF /* PrefsWindow.swift */; };
 		138D3CC824CE635800793AC1 /* Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138D3CC724CE635800793AC1 /* Commands.swift */; };
@@ -55,6 +56,7 @@
 
 /* Begin PBXFileReference section */
 		0511882B253635BD00847009 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
+		1317990A256986E5006957D8 /* String+NonNullTerminated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+NonNullTerminated.swift"; sourceTree = "<group>"; };
 		1380C36024D54BFD00A448CF /* PrefsSavedNetworksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefsSavedNetworksView.swift; sourceTree = "<group>"; };
 		1380C36424D5580200A448CF /* PrefsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefsWindow.swift; sourceTree = "<group>"; };
 		138D3CC724CE635800793AC1 /* Commands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Commands.swift; sourceTree = "<group>"; };
@@ -233,6 +235,7 @@
 				F34B2B8C24AA4C1E009AB1BB /* NSMenuItem+Extensions.swift */,
 				138D3CC724CE635800793AC1 /* Commands.swift */,
 				138D3CC924CE663B00793AC1 /* BugReporter.swift */,
+				1317990A256986E5006957D8 /* String+NonNullTerminated.swift */,
 			);
 			path = "Supporting files";
 			sourceTree = "<group>";
@@ -459,6 +462,7 @@
 				1380C36524D5580200A448CF /* PrefsWindow.swift in Sources */,
 				50F4959824BDD26D00AE4C08 /* LoginItemManager.swift in Sources */,
 				F34B2B8D24AA4C1E009AB1BB /* NSMenuItem+Extensions.swift in Sources */,
+				1317990B256986E5006957D8 /* String+NonNullTerminated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HeliPort/Appearance/StatusMenu.swift
+++ b/HeliPort/Appearance/StatusMenu.swift
@@ -497,7 +497,7 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
                 let ipAddress = NetworkManager.getLocalAddress(bsd: bsd)
                 let routerAddress = NetworkManager.getRouterAddress(bsd: bsd)
                 let isReachable = NetworkManager.isReachable()
-                disconnectName = String(cString: &staInfo.ssid.0)
+                disconnectName = String.getSSIDFromCString(cString: &staInfo.ssid.0)
                 ipAddr = ipAddress ?? .unknown
                 routerAddr = routerAddress ?? .unknown
                 internet = isReachable ? .reachable : .unreachable
@@ -541,7 +541,7 @@ final class StatusMenu: NSMenu, NSMenuDelegate {
                 if self.isNetworkConnected {
                     self.isNetworkListEmpty = false
                     wifiItemView.networkInfo = NetworkInfo(
-                        ssid: String(cString: &staInfo.ssid.0),
+                        ssid: String.getSSIDFromCString(cString: &staInfo.ssid.0),
                         rssi: Int(staInfo.rssi)
                     )
                 }

--- a/HeliPort/NetworkManager.swift
+++ b/HeliPort/NetworkManager.swift
@@ -90,9 +90,7 @@ final class NetworkManager {
                 guard var network = element as? ioctl_network_info else {
                     continue
                 }
-                let ssid = String(cString: &network.ssid.0)
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                    .replacingOccurrences(of: "[\n,\r]*", with: "", options: .regularExpression)
+                let ssid = String.getSSIDFromCString(cString: &network.ssid.0)
                 guard !ssid.isEmpty else {
                     continue
                 }

--- a/HeliPort/Supporting files/String+NonNullTerminated.swift
+++ b/HeliPort/Supporting files/String+NonNullTerminated.swift
@@ -10,7 +10,8 @@ import Foundation
 
 public extension String {
     static func getSSIDFromCString(cString: UnsafePointer<UInt8>) -> String {
-        var string = String(cString: cString)
+        var string = String(cString: cString).trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "[\n,\r]*", with: "", options: .regularExpression)
         if string.count > NWID_LEN {
             let pointer = UnsafeRawPointer(cString)
             let nsString = NSString(bytes: pointer, length: Int(NWID_LEN), encoding: Encoding.utf8.rawValue)
@@ -20,8 +21,6 @@ public extension String {
                 string = "\(string.prefix(Int(NWID_LEN)))"
             }
         }
-        return string.trimmingCharacters(in: .whitespacesAndNewlines)
-            .replacingOccurrences(of: "[\n,\r]*", with: "", options: .regularExpression)
-
+        return string
     }
 }

--- a/HeliPort/Supporting files/String+NonNullTerminated.swift
+++ b/HeliPort/Supporting files/String+NonNullTerminated.swift
@@ -1,0 +1,27 @@
+//
+//  String+NonNullTerminated.swift
+//  HeliPort
+//
+//  Created by Erik Bautista on 11/21/20.
+//  Copyright © 2020 OpenIntelWireless. All rights reserved.
+//
+
+import Foundation
+
+public extension String {
+    static func getSSIDFromCString(cString: UnsafePointer<UInt8>) -> String {
+        var string = String(cString: cString)
+        if string.count > NWID_LEN {
+            let pointer = UnsafeRawPointer(cString)
+            let nsString = NSString(bytes: pointer, length: Int(NWID_LEN), encoding: Encoding.utf8.rawValue)
+            if let nsString = nsString {
+                string = nsString as String
+            } else {
+                string = "\(string.prefix(Int(NWID_LEN)))"
+            }
+        }
+        return string.trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "[\n,\r]*", with: "", options: .regularExpression)
+
+    }
+}


### PR DESCRIPTION
This fixes issue https://github.com/OpenIntelWireless/HeliPort/issues/189.

It also fixes rare issue when random characters would appear if `ssid.count == 32`.