### PR TITLE
Add swiftlint workflow for pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
       with:
         url: https://github.com/realm/SwiftLint
         version: '*'
-    - run: swiftlint lint .
+    - run: swiftlint lint --strict .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: master
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: Cyberbeni/install-swift-tool@v2
+      with:
+        url: https://github.com/realm/SwiftLint
+        version: '*'
+    - run: swiftlint lint .


### PR DESCRIPTION
Push on master trigger is required because of caching security restrictions, other branches can use the cache from the default branch but not from each other.